### PR TITLE
Fix for failing to zero-initialize Win32API structure.

### DIFF
--- a/ext/win32/api.c
+++ b/ext/win32/api.c
@@ -66,6 +66,7 @@ static void api_free(Win32API* ptr){
 
 static VALUE api_allocate(VALUE klass){
    Win32API* ptr = malloc(sizeof(Win32API));
+   memset(ptr, 0, sizeof(*ptr));
    return Data_Wrap_Struct(klass, 0, api_free, ptr);
 }
 


### PR DESCRIPTION
If api_init raises before assigning to the library member, api_free will attempt to FreeLibrary an uninitialized value.
This will result in undefined behavior (an access violation, more often than not).
With a debugger attached to ruby.exe, it's easy to reproduce with: `Win32::API.new('foo', 'V', 'V', 'foo')`, without a foo.dll on the load path, and waiting for the API object to be collected.
