### PR TITLE
Add Ruby 2.4 binary tasks

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+== 1.6.1.beta1 - 14-Jan-201
+* Now includes binaries for Ruby 2.4 for both 32 and 64 bit versions.
+* Try to depends on MSYS2 based RubyInstaller2 on Ruby 2.4.
+
 == 1.6.0 - 09-Jun-2016
 * Now includes binaries for Ruby 2.3 for both 32 and 64 bit versions.
 * Now drop support Ruby 1.9 or earlier.

--- a/Rakefile
+++ b/Rakefile
@@ -89,7 +89,14 @@ namespace 'gem' do
           ENV['PATH'] = "C:/Devkit/bin;C:/Devkit/mingw/bin;" + ENV['PATH']
         end
       elsif key[1][:msys] == :msys2
-        ENV['PATH'] = "C:/msys64/usr/bin;" + ENV['PATH']
+        ENV.delete('RI_DEVKIT')
+        devkit = nil
+        # Adjust devkit paths as needed.
+        if `"#{key[1][:path]}" -v` =~ /x64/i
+          ENV['PATH'] = "C:/msys64/usr/bin;C:/msys64/mingw64/bin;" + ENV['PATH']
+        else
+          ENV['PATH'] = "C:/msys64/usr/bin;C:/msys64/mingw32/bin;" + ENV['PATH']
+        end
       end
       mkdir_p "lib/win32/#{key.first}/win32"
 
@@ -102,6 +109,7 @@ namespace 'gem' do
 
       ENV['PATH'] = default_path
     }
+
 text = <<HERE
 require 'rbconfig'
 begin

--- a/Rakefile
+++ b/Rakefile
@@ -89,7 +89,7 @@ namespace 'gem' do
           ENV['PATH'] = "C:/Devkit/bin;C:/Devkit/mingw/bin;" + ENV['PATH']
         end
       elsif key[1][:msys] == :msys2
-        ENV['PATH'] = "C:/msys2/usr/bin;" + ENV['PATH']
+        ENV['PATH'] = "C:/msys64/usr/bin;" + ENV['PATH']
       end
       mkdir_p "lib/win32/#{key.first}/win32"
 

--- a/Rakefile
+++ b/Rakefile
@@ -59,7 +59,7 @@ namespace 'gem' do
   end
 
   desc 'Build a binary gem'
-  task :binary, :ruby2_32, :ruby2_64, :ruby21, :ruby21_64, :ruby22, :ruby22_64, :ruby23_32, :ruby23_64 do |task, args|
+  task :binary, :ruby2_32, :ruby2_64, :ruby21, :ruby21_64, :ruby22, :ruby22_64, :ruby23_32, :ruby23_64, :ruby24_32, :ruby24_64 do |task, args|
     # These are just what's on my system at the moment. Adjust as needed.
     args.with_defaults(
       :ruby2_32  => "c:/ruby200/bin/ruby",
@@ -69,7 +69,9 @@ namespace 'gem' do
       :ruby22_32 => "c:/ruby22/bin/ruby",
       :ruby22_64 => "c:/ruby22-x64/bin/ruby",
       :ruby23_32 => "c:/ruby23/bin/ruby",
-      :ruby23_64 => "c:/ruby23-x64/bin/ruby"
+      :ruby23_64 => "c:/ruby23-x64/bin/ruby",
+      :ruby24_32 => "c:/ruby24/bin/ruby",
+      :ruby24_64 => "c:/ruby24-x64/bin/ruby"
     )
 
     Rake::Task[:clobber].invoke
@@ -126,6 +128,14 @@ begin
         require File.join(File.dirname(__FILE__), 'ruby23_64/win32/api')
       else
         require File.join(File.dirname(__FILE__), 'ruby23_32/win32/api')
+      end
+    end
+
+    if RbConfig::CONFIG['MINOR'] == '4'
+      if RbConfig::CONFIG['arch'] =~ /x64/i
+        require File.join(File.dirname(__FILE__), 'ruby24_64/win32/api')
+      else
+        require File.join(File.dirname(__FILE__), 'ruby24_32/win32/api')
       end
     end
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,16 @@ install:
   - "%devkit32%\\devkitvars.bat"
   # Update pacman database.
   - c:/msys64/usr/bin/bash -lc "pacman -Sy --noconfirm"
+  - c:/msys64/usr/bin/bash -lc "pacman -S --noconfirm pacman"
+  - c:/msys64/usr/bin/bash -lc "pacman -R --noconfirm repman-git"
   # for 32 bit ext library.
   - c:/msys64/usr/bin/bash -lc "pacman -S --noconfirm --needed base-devel mingw-w64-i686-toolchain"
   # for 64 bit ext library.
   - c:/msys64/usr/bin/bash -lc "pacman -S --noconfirm --needed base-devel mingw-w64-x86_64-toolchain"
+  - ps: Start-FileDownload https://github.com/larskanis/rubyinstaller2/releases/download/2.4.0-6/rubyinstaller-2.4.0-6-x86.exe
+  - rubyinstaller-2.4.0-6-x86.exe TYPE=full /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /CLOSEAPPLICATIONS /NORESTARTAPPLICATIONS /DIR="C:\Ruby24"
+  - ps: Start-FileDownload https://github.com/larskanis/rubyinstaller2/releases/download/2.4.0-6/rubyinstaller-2.4.0-6-x64.exe
+  - rubyinstaller-2.4.0-6-x64.exe TYPE=full /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /CLOSEAPPLICATIONS /NORESTARTAPPLICATIONS /DIR="C:\Ruby24-x64"
   - ruby --version
   - gem --version
   - bundle install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,12 @@ install:
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - "%devkit64%\\devkitvars.bat"
   - "%devkit32%\\devkitvars.bat"
+  # Update pacman database.
+  - c:/msys64/usr/bin/bash -lc "pacman -Sy --noconfirm"
+  # for 32 bit ext library.
+  - c:/msys64/usr/bin/bash -lc "pacman -S --noconfirm --needed base-devel mingw-w64-i686-toolchain"
+  # for 64 bit ext library.
+  - c:/msys64/usr/bin/bash -lc "pacman -S --noconfirm --needed base-devel mingw-w64-x86_64-toolchain"
   - ruby --version
   - gem --version
   - bundle install

--- a/win32-api.gemspec
+++ b/win32-api.gemspec
@@ -2,7 +2,7 @@ require 'rubygems'
 
 Gem::Specification.new do |spec|
   spec.name       = 'win32-api'
-  spec.version    = '1.6.0'
+  spec.version    = '1.6.1.beta1'
   spec.authors    = ['Daniel J. Berger', 'Park Heesob', 'Hiroshi Hatake']
   spec.license    = 'Artistic 2.0'
   spec.email      = 'djberg96@gmail.com'


### PR DESCRIPTION
I think that it only needs to support Ruby 2.4 in this gem.
But for now, RubyInstaller which installs Ruby 2.4 is not released yet. :(

Related to #23.