### PR TITLE
Add gcc option to fix crash on RubyInstaller2 x86

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ install:
   - ruby --version
   - gem --version
   - IF %msys2%==1 ridk.cmd enable
-  - IF %msys2%==1 gem install bundler
+  - IF %msys2%==1 gem install bundler --force
   - bundle install
 build: off
 test_script:

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -6,6 +6,10 @@
 ##########################################################################
 require 'mkmf'
 
+if RbConfig::CONFIG['host_os'] =~ /mingw/
+  $CFLAGS << ' -fno-omit-frame-pointer'
+end
+
 have_func('strncpy_s')
 
 create_makefile('win32/api', 'win32')


### PR DESCRIPTION
RubyInstaller2 build doesn't use -fno-omit-frame-pointer gcc
optimization option.
This causes crash with api_call.

Fix https://github.com/cosmo0920/windows-pr/issues/21