### PR TITLE
Remove bundle exec

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,8 +20,8 @@ install:
 build: off
 
 test_script:
-  - bundle exec rake gem:binary
-  - bundle exec rake -rdevkit test:all
+  - rake gem:binary
+  - rake -rdevkit test:all
 
 environment:
   matrix:


### PR DESCRIPTION
Per previous, there's an issue with ruby trunk and `rake gem:binary`.  The real issue is running the command from `bundle exec`.

As it's somewhat unnecessary here, I removed it, and everything passes...