### PR TITLE
Run CI for Ruby 2.6

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -94,8 +94,8 @@ namespace 'gem' do
         :ruby24_64 => {:path => "#{pre}/ruby24-x64/bin",  :ri => :ri2_64, :omit => false},
         :ruby25_32 => {:path => "#{pre}/ruby25/bin",      :ri => :ri2,    :omit => false},
         :ruby25_64 => {:path => "#{pre}/ruby25-x64/bin",  :ri => :ri2_64, :omit => false},
-        :ruby26_32 => {:path => "#{pre}/ruby26/bin",      :ri => :ri2,    :omit => true},
-        :ruby26_64 => {:path => "#{pre}/ruby26-x64/bin",  :ri => :ri2_64, :omit => true},
+        :ruby26_32 => {:path => "#{pre}/ruby26/bin",      :ri => :ri2,    :omit => false},
+        :ruby26_64 => {:path => "#{pre}/ruby26-x64/bin",  :ri => :ri2_64, :omit => false},
         :ruby27_32 => {:path => "#{pre}/ruby27/bin",      :ri => :ri2,    :omit => true},
         :ruby27_64 => {:path => "#{pre}/ruby27-x64/bin",  :ri => :ri2_64, :omit => true},
       }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,8 @@ test_script:
 environment:
   matrix:
     - ruby_version: _trunk
+    - ruby_version: 26-x64
+    - ruby_version: 26
     - ruby_version: 25-x64
     - ruby_version: 25
     - ruby_version: 24-x64


### PR DESCRIPTION
We can use Ruby 2.6.1 on AppVeyor.
https://www.appveyor.com/updates/2019/02/11/