### PR TITLE
Add API.last_error

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,7 @@
 version: '{build}'
 
+image: Visual Studio 2019
+
 init:
   # use a minimal path
   - set PATH=C:\ruby%ruby_version%\bin;C:\Program Files\7-Zip;C:\Program Files\AppVeyor\BuildAgent;C:\Program Files\Git\cmd;C:\Windows\system32

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -40,12 +40,6 @@ environment:
     - ruby_version: 24
     - ruby_version: 23-x64
     - ruby_version: 23
-    - ruby_version: 22-x64
-    - ruby_version: 22
-    - ruby_version: 21-x64
-    - ruby_version: 21
-    - ruby_version: 200-x64
-    - ruby_version: 200
 
 matrix:
   allow_failures:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,10 @@ test_script:
 environment:
   matrix:
     - ruby_version: _trunk
+    - ruby_version: 30-x64
+    - ruby_version: 30
+    - ruby_version: 27-x64
+    - ruby_version: 27
     - ruby_version: 26-x64
     - ruby_version: 26
     - ruby_version: 25-x64

--- a/test/test_win32_api.rb
+++ b/test/test_win32_api.rb
@@ -43,6 +43,12 @@ class TC_Win32_API < Test::Unit::TestCase
       assert_equal(0xFFFFFFFF, @gfa.call('C:/foobarbazblah'))
    end
 
+   def test_last_error
+      @gfa.call('C:/foobarbazblah')
+      error_file_not_found = 2
+      assert_equal(error_file_not_found, API.last_error)
+   end
+
    def test_dll_name
       assert_respond_to(@gcd, :dll_name)
       assert_equal('kernel32', @gcd.dll_name)


### PR DESCRIPTION
Because Ruby may call Win32 API and reset the error code before a user
calls GetLastError(), the user might not be able to correct error code.
To avoid it win32-api should store last error code like FFI or Fiddle
do it. FYI:

* FFI::LastError.winapi_error
  https://www.rubydoc.info/github/ffi/ffi/FFI/LastError#winapi_error-class_method
* Fiddle.win32_last_error
  https://rubyapi.org/3.0/o/fiddle#method-c-win32_last_error

Signed-off-by: Takuro Ashie <ashie@clear-code.com>