### PR TITLE
Creating a Chef-Win32-API gem

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '3.0' , '3.1' ]
         os:
           - windows-latest
         experimental: [false]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,108 +6,32 @@ LABEL Description="win32-api building docker image"
 # Docker creates a layer for every RUN-Statement
 RUN powershell -Command "Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))"
 
-# Ruby 2.0.0
-RUN powershell \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -OutFile C:\rubyinstaller-2.0.0-p648.exe https://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.0.0-p648.exe
-RUN cmd /c "C:\rubyinstaller-2.0.0-p648.exe" /silent /dir=c:\ruby200
-RUN powershell \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -OutFile C:\rubyinstaller-2.0.0-p648-x64.exe https://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.0.0-p648-x64.exe
-RUN cmd /c "C:\rubyinstaller-2.0.0-p648-x64.exe" /silent /dir=c:\ruby200-x64
-# Ruby 2.1
-RUN powershell \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -OutFile C:\rubyinstaller-2.1.9.exe https://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.1.9.exe
-RUN cmd /c "C:\rubyinstaller-2.1.9.exe" /silent /dir=c:\ruby21
-RUN powershell \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -OutFile C:\rubyinstaller-2.1.9-x64.exe https://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.1.9-x64.exe
-RUN cmd /c "C:\rubyinstaller-2.1.9-x64.exe" /silent /dir=c:\ruby21-x64
-# Ruby 2.2
-RUN powershell \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -OutFile C:\rubyinstaller-2.2.6.exe https://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.2.6.exe
-RUN cmd /c "C:\rubyinstaller-2.2.6.exe" /silent /dir=c:\ruby22
-RUN powershell \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -OutFile C:\rubyinstaller-2.2.6-x64.exe https://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.2.6-x64.exe
-RUN cmd /c "C:\rubyinstaller-2.2.6-x64.exe" /silent /dir=c:\ruby22-x64
-# Ruby 2.3
-RUN powershell \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -OutFile C:\rubyinstaller-2.3.3.exe https://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.3.3.exe
-RUN cmd /c "C:\rubyinstaller-2.3.3.exe" /silent /dir=c:\ruby23
-RUN powershell \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -OutFile C:\rubyinstaller-2.3.3-x64.exe https://dl.bintray.com/oneclick/rubyinstaller/rubyinstaller-2.3.3-x64.exe
-RUN cmd /c "C:\rubyinstaller-2.3.3-x64.exe" /silent /dir=c:\ruby23-x64
-# Ruby 2.4
-RUN powershell \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -OutFile C:\rubyinstaller-2.4.9-1-x86.exe https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.4.9-1/rubyinstaller-2.4.9-1-x86.exe
-RUN cmd /c "C:\rubyinstaller-2.4.9-1-x86.exe" /silent /dir=c:\ruby24
-RUN powershell \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -OutFile C:\rubyinstaller-2.4.9-1-x64.exe https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.4.9-1/rubyinstaller-2.4.9-1-x64.exe
-RUN cmd /c "C:\rubyinstaller-2.4.9-1-x64.exe" /silent /dir=c:\ruby24-x64
-# Ruby 2.5
-RUN powershell \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -OutFile C:\rubyinstaller-2.5.7-1-x86.exe https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.5.7-1/rubyinstaller-2.5.7-1-x86.exe
-RUN cmd /c "C:\rubyinstaller-2.5.7-1-x86.exe" /silent /dir=c:\ruby25
-RUN powershell \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -OutFile C:\rubyinstaller-2.5.7-1-x64.exe https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.5.7-1/rubyinstaller-2.5.7-1-x64.exe
-RUN cmd /c "C:\rubyinstaller-2.5.7-1-x64.exe" /silent /dir=c:\ruby25-x64
-# Ruby 2.6
-RUN powershell \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -OutFile C:\rubyinstaller-2.6.5-1-x86.exe https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.6.5-1/rubyinstaller-2.6.5-1-x86.exe
-RUN cmd /c "C:\rubyinstaller-2.6.5-1-x86.exe" /silent /dir=c:\ruby26
-RUN powershell \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -OutFile C:\rubyinstaller-2.6.5-1-x64.exe https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.6.5-1/rubyinstaller-2.6.5-1-x64.exe
-RUN cmd /c "C:\rubyinstaller-2.6.5-1-x64.exe" /silent /dir=c:\ruby26-x64
-
-# Ruby 2.7
-RUN powershell \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -OutFile C:\rubyinstaller-2.7.0-1-x86.exe https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.7.0-1/rubyinstaller-2.7.0-1-x86.exe
-RUN cmd /c "C:\rubyinstaller-2.7.0-1-x86.exe" /silent /dir=c:\ruby27
-RUN powershell \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -OutFile C:\rubyinstaller-2.7.0-1-x64.exe https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-2.7.0-1/rubyinstaller-2.7.0-1-x64.exe
-RUN cmd /c "C:\rubyinstaller-2.7.0-1-x64.exe" /silent /dir=c:\ruby27-x64
-
-# Ruby 3.0
-RUN powershell \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -OutFile C:\rubyinstaller-3.0.0-1-x86.exe https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.0.0-1/rubyinstaller-3.0.0-1-x86.exe
-RUN cmd /c "C:\rubyinstaller-3.0.0-1-x86.exe" /silent /dir=c:\ruby30
+# Ruby 3.0 and 3.1
 RUN powershell \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -OutFile C:\rubyinstaller-3.0.0-1-x64.exe https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.0.0-1/rubyinstaller-3.0.0-1-x64.exe
 RUN cmd /c "C:\rubyinstaller-3.0.0-1-x64.exe" /silent /dir=c:\ruby30-x64
+RUN powershell \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -OutFile C:\rubyinstaller-3.1.6-1-x64.exe https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.6-1/rubyinstaller-3.1.6-1-x64.exe
+RUN cmd /c "C:\rubyinstaller-3.1.6-1-x64.exe" /silent /dir=c:\ruby31-x64
 
 # DevKit
 RUN powershell \
 	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
-	Invoke-WebRequest -OutFile C:\DevKit-mingw64-32-4.7.2-20130224-1151-sfx.exe https://dl.bintray.com/oneclick/rubyinstaller/DevKit-mingw64-32-4.7.2-20130224-1151-sfx.exe
-RUN cmd /c C:\DevKit-mingw64-32-4.7.2-20130224-1151-sfx.exe -o"c:\DevKit" -y
-RUN powershell \
-	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
 	Invoke-WebRequest -OutFile C:\DevKit-mingw64-64-4.7.2-20130224-1432-sfx.exe https://dl.bintray.com/oneclick/rubyinstaller/DevKit-mingw64-64-4.7.2-20130224-1432-sfx.exe
 RUN cmd /c C:\DevKit-mingw64-64-4.7.2-20130224-1432-sfx.exe -o"c:\DevKit64" -y
+RUN powershell \
+	[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; \
+	Invoke-WebRequest -OutFile rubyinstaller-devkit-3.1.6-1-x64.exe https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.1.6-1/rubyinstaller-devkit-3.1.6-1-x64.exe
+RUN cmd /c rubyinstaller-devkit-3.1.6-1-x64.exe -o"c:\DevKit64" -y
 
 RUN choco install -y git \
     && choco install -y msys2 --params "'/NoPath /NoUpdate /InstallDir:C:\msys64'"
 # pacman -Syu --noconfirm is needed for downloading ucrt64 repo.
 # They should be removed after using Ruby 2.5.9, 2.6.7, and 2.7.3 installers.
 RUN refreshenv \
-    && C:\ruby27\bin\ridk exec pacman -Syu --noconfirm \
-    && C:\ruby27\bin\ridk install 2 3 \
-    && C:\ruby27-x64\bin\ridk exec pacman -Syu --noconfirm \
-    && C:\ruby27-x64\bin\ridk install 2 3
+    && C:\ruby31-x64\bin\ridk exec pacman -Syu --noconfirm \
+    && C:\ruby31-x64\bin\ridk install 2 3
 
 ENTRYPOINT ["cmd"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Description
   This is a drop-in replacement for the Win32API library currently part of
-  Ruby's standard library.
+  Ruby's standard library. This fork is taken by Chef Infra to update it to Ruby 3.1 support
 
 # Synopsis
 

--- a/Rakefile
+++ b/Rakefile
@@ -21,12 +21,12 @@ CLEAN.include(
 
 require 'rake/extensiontask'
 
-spec = eval(File.read("win32-api.gemspec"))
+spec = eval(File.read("chef-win32-api.gemspec"))
 
 def configure_cross_compilation(ext)
   unless RUBY_PLATFORM =~ /mswin|mingw/
     ext.cross_compile = true
-    ext.cross_platform = ['x86-mingw32', 'x64-mingw32', 'x64-mingw-ucrt']
+    ext.cross_platform = ['x64-mingw32', 'x64-mingw-ucrt']
   end
 end
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ init:
 platform: x64
 
 install:
-  - set SSL_CERT_FILE=C:/ruby24-x64/ssl/cert.pem
+  - set SSL_CERT_FILE=C:/ruby31-x64/ssl/cert.pem
   - ruby --version
   - gem --version
   # Assume we can use the version of bundler that Appveyor has packaged with each ruby version
@@ -29,23 +29,7 @@ environment:
   matrix:
     - ruby_version: _trunk
     - ruby_version: 30-x64
-    - ruby_version: 30
-    - ruby_version: 27-x64
-    - ruby_version: 27
-    - ruby_version: 26-x64
-    - ruby_version: 26
-    - ruby_version: 25-x64
-    - ruby_version: 25
-    - ruby_version: 24-x64
-    - ruby_version: 24
-    - ruby_version: 23-x64
-    - ruby_version: 23
-    - ruby_version: 22-x64
-    - ruby_version: 22
-    - ruby_version: 21-x64
-    - ruby_version: 21
-    - ruby_version: 200-x64
-    - ruby_version: 200
+    - ruby_version: 31-x64
 
 matrix:
   allow_failures:

--- a/chef-win32-api.gemspec
+++ b/chef-win32-api.gemspec
@@ -1,8 +1,8 @@
 require 'rubygems'
 
 Gem::Specification.new do |spec|
-  spec.name       = 'win32-api'
-  spec.version    = '1.10.1'
+  spec.name       = 'chef-win32-api'
+  spec.version    = '1.11.0'
   spec.authors    = ['Daniel J. Berger', 'Park Heesob', 'Hiroshi Hatake']
   spec.license    = 'Artistic-2.0'
   spec.email      = 'djberg96@gmail.com'
@@ -12,12 +12,17 @@ Gem::Specification.new do |spec|
   spec.extensions = ['ext/win32/extconf.rb']
   spec.files      = Dir['**/*'].reject{ |f| f.include?('git') }
 
-  spec.required_ruby_version = '>= 1.8.2'
+  if RUBY_VERSION.match? /(3.0.\d)/
+    spec.required_ruby_version = '>= 3.0.0'
+  else
+    spec.required_ruby_version = '>= 3.1.6'
+  end
+
   spec.extra_rdoc_files = ['CHANGES', 'MANIFEST', 'ext/win32/api.c']
 
-  spec.add_development_dependency('test-unit', '>= 2.5.0')
+  spec.add_development_dependency('test-unit', '>= 3.6.7')
   spec.add_development_dependency('rake')
-  spec.add_development_dependency("rake-compiler", ">= 1.1.9")
+  spec.add_development_dependency("rake-compiler", ">= 1.2.9")
 
   spec.description = <<-EOF
     The Win32::API library is meant as a replacement for the Win32API


### PR DESCRIPTION
The Win32-api gem is super stale and was last updated like 3-4 years ago. We had to update it for ucrt libs. That required a full rename for us to manage this correctly.